### PR TITLE
errored should be int not duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -421,7 +421,7 @@ func main() {
 			elapsedSum := time.Duration(0)
 			maxElapsed := time.Duration(0)
 			minElapsed := time.Duration(0)
-			errored := time.Duration(0)
+			errored := 0
 
 			statuses := make(map[int]int)
 			for _, test := range tests {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getVersion() string {
-	return "1.0.0-alpha"
+	return "1.0.1-alpha"
 }
 
 func marshalTest(format string, tests []*endpointTest) (string, error) {


### PR DESCRIPTION
Signed-off-by: Curtis La Graff <curtis@lagraff.me>

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What is the current behavior?**
<!-- please link to open issue if one exists -->
Issue #8 , the # of responses which errored is currently displayed as a duration.


* **What is the new behavior (if this is a feature change)?**
The # of responses which errored is no displayed as a normal int.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:



